### PR TITLE
Adds support for tags, summary, and description on operations

### DIFF
--- a/lib/swagger/dsl/operation.rb
+++ b/lib/swagger/dsl/operation.rb
@@ -19,8 +19,23 @@ module Swagger
         self["requestBody"] = { "content" => {}, "required" => true }
         self["responses"] = {}
         self["parameters"] = []
+        self["tags"] = []
+        self["description"] = ""
+        self["summary"] = ""
         @format = format
         instance_eval(&block)
+      end
+
+      def summary(text)
+        self["summary"] = text
+      end
+
+      def description(text)
+        self["description"] = text
+      end
+
+      def tag(text)
+        self["tags"] << text
       end
 
       def params(default_required: Swagger::DSL.current.config.default_required, &block)

--- a/lib/swagger/dsl/operation.rb
+++ b/lib/swagger/dsl/operation.rb
@@ -20,8 +20,6 @@ module Swagger
         self["responses"] = {}
         self["parameters"] = []
         self["tags"] = []
-        self["description"] = ""
-        self["summary"] = ""
         @format = format
         instance_eval(&block)
       end
@@ -34,8 +32,8 @@ module Swagger
         self["description"] = text
       end
 
-      def tag(text)
-        self["tags"] << text
+      def tags(*tags)
+        self["tags"].concat(tags.flatten(1))
       end
 
       def params(default_required: Swagger::DSL.current.config.default_required, &block)

--- a/spec/swagger/dsl_spec.rb
+++ b/spec/swagger/dsl_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Swagger::DSL do
 
   let(:patch) do
     {
+      "summary" => "Update a user",
+      "description" => "Lorem ipsum dolor sit amet.",
+      "tags" => [ "Users", "Updates" ],
       "operationId" => "UsersController#update",
       "parameters" => [
         { "name" => :id, "schema" => { "type" => :integer }, "required" => true, "in" => :path },

--- a/spec/swagger/rails_fixture.rb
+++ b/spec/swagger/rails_fixture.rb
@@ -36,6 +36,10 @@ end
 
 class UsersController < ApplicationController
   swagger :update do
+    summary "Update a user"
+    description "Lorem ipsum dolor sit amet."
+    tag "Users"
+    tag "Updates"
     params do
       path :id, schema: :integer
       query do

--- a/spec/swagger/rails_fixture.rb
+++ b/spec/swagger/rails_fixture.rb
@@ -38,8 +38,7 @@ class UsersController < ApplicationController
   swagger :update do
     summary "Update a user"
     description "Lorem ipsum dolor sit amet."
-    tag "Users"
-    tag "Updates"
+    tags "Users", "Updates"
     params do
       path :id, schema: :integer
       query do


### PR DESCRIPTION
Hi @Narazaka,

I noticed that Operations were missing support for `tags`, `summary` and `description`. Not sure if this was on purpose or not, but I've added them here. Let me know if you think anything needs to change about this.